### PR TITLE
Include all the test_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
 
     packages=find_packages(),
     package_data={
-        "smart_open.tests": ["test_data/*gz"],
+        "smart_open.tests": ["test_data/*"],
     },
 
     author='Radim Rehurek',


### PR DESCRIPTION
Hi,

`setup.py` only includes `test_data/*gz` files, and lacking [other files](https://github.com/RaRe-Technologies/smart_open/tree/master/smart_open/tests/test_data).

This PR will include all the files in `test_data/`.

Closes: #472